### PR TITLE
Fix Rounding calculation and Accuracy Calculation

### DIFF
--- a/pkg/float16bits/float16.go
+++ b/pkg/float16bits/float16.go
@@ -280,6 +280,10 @@ func FromFloat32(input float32, rm floatBit.RoundingMode,
 	alignedMantissa := mantissaBits
 	adjustedExponent := uint32(actualExponent + ExponentBias)
 
+	// Value that indicates whether any precision was lost when preprocessing
+	// the mantissa before passing it down to the rounding routines
+	lostPrecision := false
+
 	// Before performing any rounding, we need to make sure this exponent
 	// can actually be represented in the float32 format. If the exponent,
 	// is smaller than the minimum exponent allowed in float32 (-126), this
@@ -305,10 +309,6 @@ func FromFloat32(input float32, rm floatBit.RoundingMode,
 		// And also, for the subnormal case, we need to set the adjusted
 		// exponent bits to 0
 		adjustedExponent = 0
-
-		// For accurately determining underflow, we also need to check
-		// if we shifted any 1s to the right
-		lostPrecision := false
 
 		// Now, to align the bits of the original format, with the mantissa
 		// of the destination format as a subnormal, we have to shift right
@@ -357,28 +357,28 @@ func FromFloat32(input float32, rm floatBit.RoundingMode,
 	switch rm {
 	case floatBit.RoundTowardsZero:
 		resultVal, resultAcc = roundTowardsZero(signBit,
-			adjustedExponent, alignedMantissa)
+			adjustedExponent, alignedMantissa, lostPrecision)
 	case floatBit.RoundTowardsNegativeInf:
 		resultVal, resultAcc = roundTowardsNegativeInf(signBit,
-			adjustedExponent, alignedMantissa)
+			adjustedExponent, alignedMantissa, lostPrecision)
 	case floatBit.RoundTowardsPositiveInf:
 		resultVal, resultAcc = roundTowardsPositiveInf(signBit,
-			adjustedExponent, alignedMantissa)
+			adjustedExponent, alignedMantissa, lostPrecision)
 	case floatBit.RoundHalfTowardsZero:
 		resultVal, resultAcc = roundHalfTowardsZero(signBit, adjustedExponent,
-			alignedMantissa)
+			alignedMantissa, lostPrecision)
 	case floatBit.RoundHalfTowardsNegativeInf:
 		resultVal, resultAcc = roundHalfTowardsNegativeInf(signBit,
-			adjustedExponent, alignedMantissa)
+			adjustedExponent, alignedMantissa, lostPrecision)
 	case floatBit.RoundHalfTowardsPositiveInf:
 		resultVal, resultAcc = roundHalfTowardsPositiveInf(signBit,
-			adjustedExponent, alignedMantissa)
+			adjustedExponent, alignedMantissa, lostPrecision)
 	case floatBit.RoundNearestEven:
 		resultVal, resultAcc = roundNearestEven(signBit, adjustedExponent,
-			alignedMantissa)
+			alignedMantissa, lostPrecision)
 	case floatBit.RoundNearestOdd:
 		resultVal, resultAcc = roundNearestOdd(signBit, adjustedExponent,
-			alignedMantissa)
+			alignedMantissa, lostPrecision)
 	}
 
 	return resultVal, resultAcc, floatBit.Fits

--- a/pkg/float16bits/float16_test.go
+++ b/pkg/float16bits/float16_test.go
@@ -271,7 +271,7 @@ func TestRoundTowardsZero(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run("RoundTowardsZero", func(t *testing.T) {
-			resultVal, resultAcc := truncate(tt.signBit, tt.exponentBits, tt.mantissaBits)
+			resultVal, resultAcc := truncate(tt.signBit, tt.exponentBits, tt.mantissaBits, false)
 			if (resultVal != tt.goldenVal) || (resultAcc != tt.goldenAcc) {
 				t.Logf("Failed Input Set:\n")
 				t.Logf("signBit: %#08x, exponentBits: %#08x, mantissaBits: %#08x", tt.signBit, tt.exponentBits, tt.mantissaBits)
@@ -340,7 +340,7 @@ func TestRoundTowardsPositiveInf(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run("RoundTowardsPositiveInf", func(t *testing.T) {
-			resultVal, resultAcc := roundTowardsPositiveInf(tt.signBit, tt.exponentBits, tt.mantissaBits)
+			resultVal, resultAcc := roundTowardsPositiveInf(tt.signBit, tt.exponentBits, tt.mantissaBits, false)
 			if (resultVal != tt.goldenVal) || (resultAcc != tt.goldenAcc) {
 				t.Logf("Failed Input Set:\n")
 				t.Logf("signBit: %#08x, exponentBits: %#08x, mantissaBits: %#08x", tt.signBit, tt.exponentBits, tt.mantissaBits)
@@ -409,7 +409,7 @@ func TestRoundTowardsNegativeInf(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run("RoundTowardsNegativeInf", func(t *testing.T) {
-			resultVal, resultAcc := roundTowardsNegativeInf(tt.signBit, tt.exponentBits, tt.mantissaBits)
+			resultVal, resultAcc := roundTowardsNegativeInf(tt.signBit, tt.exponentBits, tt.mantissaBits, false)
 			if (resultVal != tt.goldenVal) || (resultAcc != tt.goldenAcc) {
 				t.Logf("Failed Input Set:\n")
 				t.Logf("signBit: %#08x, exponentBits: %#08x, mantissaBits: %#08x", tt.signBit, tt.exponentBits, tt.mantissaBits)
@@ -551,7 +551,7 @@ func TestRoundHalfTowardsZero(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run("RoundHalfTowardsZero", func(t *testing.T) {
-			resultVal, resultAcc := roundHalfTowardsZero(tt.signBit, tt.exponentBits, tt.mantissaBits)
+			resultVal, resultAcc := roundHalfTowardsZero(tt.signBit, tt.exponentBits, tt.mantissaBits, false)
 			if (resultVal != tt.goldenVal) || (resultAcc != tt.goldenAcc) {
 				t.Logf("Failed Input Set:\n")
 				t.Logf("signBit: %#08x, exponentBits: %#08x, mantissaBits: %#08x", tt.signBit, tt.exponentBits, tt.mantissaBits)
@@ -694,7 +694,7 @@ func TestRoundHalfTowardsPositiveInf(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run("RoundHalfTowardsPositiveInf", func(t *testing.T) {
-			resultVal, resultAcc := roundHalfTowardsPositiveInf(tt.signBit, tt.exponentBits, tt.mantissaBits)
+			resultVal, resultAcc := roundHalfTowardsPositiveInf(tt.signBit, tt.exponentBits, tt.mantissaBits, false)
 			if (resultVal != tt.goldenVal) || (resultAcc != tt.goldenAcc) {
 				t.Logf("Failed Input Set:\n")
 				t.Logf("signBit: %#08x, exponentBits: %#08x, mantissaBits: %#08x", tt.signBit, tt.exponentBits, tt.mantissaBits)
@@ -837,7 +837,7 @@ func TestRoundHalfTowardsNegativeInf(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run("RoundHalfTowardsNegativeInf", func(t *testing.T) {
-			resultVal, resultAcc := roundHalfTowardsNegativeInf(tt.signBit, tt.exponentBits, tt.mantissaBits)
+			resultVal, resultAcc := roundHalfTowardsNegativeInf(tt.signBit, tt.exponentBits, tt.mantissaBits, false)
 			if (resultVal != tt.goldenVal) || (resultAcc != tt.goldenAcc) {
 				t.Logf("Failed Input Set:\n")
 				t.Logf("signBit: %#08x, exponentBits: %#08x, mantissaBits: %#08x", tt.signBit, tt.exponentBits, tt.mantissaBits)
@@ -1018,7 +1018,7 @@ func TestRoundNearestEven(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run("RoundHalfTowardsNegativeInf", func(t *testing.T) {
-			resultVal, resultAcc := roundNearestEven(tt.signBit, tt.exponentBits, tt.mantissaBits)
+			resultVal, resultAcc := roundNearestEven(tt.signBit, tt.exponentBits, tt.mantissaBits, false)
 			if (resultVal != tt.goldenVal) || (resultAcc != tt.goldenAcc) {
 				t.Logf("Failed Input Set:\n")
 				t.Logf("signBit: %#08x, exponentBits: %#08x, mantissaBits: %#08x", tt.signBit, tt.exponentBits, tt.mantissaBits)
@@ -1191,7 +1191,7 @@ func TestRoundNearestOdd(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run("RoundHalfTowardsNegativeInf", func(t *testing.T) {
-			resultVal, resultAcc := roundNearestOdd(tt.signBit, tt.exponentBits, tt.mantissaBits)
+			resultVal, resultAcc := roundNearestOdd(tt.signBit, tt.exponentBits, tt.mantissaBits, false)
 			if (resultVal != tt.goldenVal) || (resultAcc != tt.goldenAcc) {
 				t.Logf("Failed Input Set:\n")
 				t.Logf("signBit: %#016x, exponentBits: %#016x, mantissaBits: %#016x", tt.signBit, tt.exponentBits, tt.mantissaBits)
@@ -1342,7 +1342,7 @@ func TestFromBigFloat(t *testing.T) {
 			um:           floatBit.FlushToZero,
 			om:           floatBit.SaturateMax,
 			goldenVal:    Bits(0x0130),
-			goldenAcc:    big.Exact,
+			goldenAcc:    big.Below,
 			goldenStatus: floatBit.Fits,
 		},
 		{
@@ -1352,7 +1352,7 @@ func TestFromBigFloat(t *testing.T) {
 			um:           floatBit.FlushToZero,
 			om:           floatBit.SaturateMax,
 			goldenVal:    Bits(0x8130),
-			goldenAcc:    big.Exact,
+			goldenAcc:    big.Above,
 			goldenStatus: floatBit.Fits,
 		},
 		{
@@ -1361,8 +1361,8 @@ func TestFromBigFloat(t *testing.T) {
 			rm:           floatBit.RoundTowardsPositiveInf,
 			um:           floatBit.FlushToZero,
 			om:           floatBit.SaturateMax,
-			goldenVal:    Bits(0x0130),
-			goldenAcc:    big.Exact,
+			goldenVal:    Bits(0x0131),
+			goldenAcc:    big.Above,
 			goldenStatus: floatBit.Fits,
 		},
 		{
@@ -1372,7 +1372,7 @@ func TestFromBigFloat(t *testing.T) {
 			um:           floatBit.FlushToZero,
 			om:           floatBit.SaturateMax,
 			goldenVal:    Bits(0x8130),
-			goldenAcc:    big.Exact,
+			goldenAcc:    big.Above,
 			goldenStatus: floatBit.Fits,
 		},
 		{
@@ -1381,8 +1381,8 @@ func TestFromBigFloat(t *testing.T) {
 			rm:           floatBit.RoundTowardsNegativeInf,
 			um:           floatBit.FlushToZero,
 			om:           floatBit.SaturateInf,
-			goldenVal:    Bits(0x8130),
-			goldenAcc:    big.Exact,
+			goldenVal:    Bits(0x8131),
+			goldenAcc:    big.Below,
 			goldenStatus: floatBit.Fits,
 		},
 		{

--- a/pkg/float16bits/rounddown.go
+++ b/pkg/float16bits/rounddown.go
@@ -10,13 +10,15 @@ import "math/big"
 // exponentBits must be passed with the float16 bias applied
 // mantissaBits must be passed in their float32 locations.
 // NOTE: This doesn't handle the underflow and overflow cases.
+// The parameter lostPrecision indicates whether the mantissa passed had already
+// lost precision during any preprocessing
 func roundTowardsNegativeInf(signBit, exponentBits,
-	mantissaBits uint32) (Bits, big.Accuracy) {
-	return roundDown(signBit, exponentBits, mantissaBits)
+	mantissaBits uint32, lostPrecision bool) (Bits, big.Accuracy) {
+	return roundDown(signBit, exponentBits, mantissaBits, lostPrecision)
 }
 
 func roundDown(signBit, exponentBits,
-	mantissaBits uint32) (Bits, big.Accuracy) {
+	mantissaBits uint32, lostPrecision bool) (Bits, big.Accuracy) {
 
 	mantissaF16Precision := mantissaBits & f32Float16MantissaMask
 	mantissaExtraPrecision := mantissaBits & f32Float16HalfSubnormalMask
@@ -32,7 +34,7 @@ func roundDown(signBit, exponentBits,
 	exponentMantissaComposite := (float16Exponent | float16Mantissa)
 
 	// If positive and there is extra precision, then add 1
-	if (float16Sign != 0) && (mantissaExtraPrecision != 0) {
+	if (float16Sign != 0) && (mantissaExtraPrecision != 0 || lostPrecision) {
 		exponentMantissaComposite += 1
 	}
 	// Since, we don't handle overflow, all we need to do now is attach the sign
@@ -40,7 +42,7 @@ func roundDown(signBit, exponentBits,
 
 	resultAcc := big.Exact
 	// If there was extra precision bits set, then we need to
-	if mantissaExtraPrecision != 0 {
+	if mantissaExtraPrecision != 0 || lostPrecision {
 		// We always round to a smaller value
 		resultAcc = big.Below
 	}

--- a/pkg/float16bits/roundhalfdown.go
+++ b/pkg/float16bits/roundhalfdown.go
@@ -10,7 +10,7 @@ import "math/big"
 // mantissaBits must be passed in their float32 locations.
 // NOTE: This doesn't handle the underflow and overflow cases.
 func roundHalfTowardsNegativeInf(signBit, exponentBits,
-	mantissaBits uint32) (Bits, big.Accuracy) {
+	mantissaBits uint32, lostPrecision bool) (Bits, big.Accuracy) {
 
 	mantissaF16Precision := mantissaBits & f32Float16MantissaMask
 	mantissaExtraPrecision := mantissaBits & f32Float16HalfSubnormalMask
@@ -31,7 +31,7 @@ func roundHalfTowardsNegativeInf(signBit, exponentBits,
 	// In the case that we're halfway through,
 	// We add 1, only if the sign was negative, otherwise we truncate
 	if (mantissaExtraPrecision ==
-		f32Float16HalfSubnormalLSB) && (float16Sign != 0) {
+		f32Float16HalfSubnormalLSB) && (float16Sign != 0) && !lostPrecision {
 		exponentMantissaComposite += 1
 		addedOne = true
 	}
@@ -43,7 +43,7 @@ func roundHalfTowardsNegativeInf(signBit, exponentBits,
 
 	// Result is larger if the input was positive and we added 1, or
 	// if the input was negative and we truncated.
-	if mantissaExtraPrecision != 0 {
+	if mantissaExtraPrecision != 0 || lostPrecision {
 		resultAcc = big.Below
 		if (float16Sign == 0) == addedOne {
 			resultAcc = big.Above

--- a/pkg/float16bits/roundhalfdown.go
+++ b/pkg/float16bits/roundhalfdown.go
@@ -28,6 +28,14 @@ func roundHalfTowardsNegativeInf(signBit, exponentBits,
 		addedOne = true
 	}
 
+	// If extra precision was lost before, then we need to add one if we're
+	// halfway through in the adjusted mantissa (because this means we're
+	// actually greater than the midpoint)
+	if mantissaExtraPrecision == f32Float16HalfSubnormalLSB && lostPrecision {
+		exponentMantissaComposite += 1
+		addedOne = true
+	}
+
 	// In the case that we're halfway through,
 	// We add 1, only if the sign was negative, otherwise we truncate
 	if (mantissaExtraPrecision ==

--- a/pkg/float16bits/roundhalftowardszero.go
+++ b/pkg/float16bits/roundhalftowardszero.go
@@ -9,8 +9,10 @@ import "math/big"
 // exponentBits must be passed with the float16 bias applied
 // mantissaBits must be passed in their float32 locations.
 // NOTE: This doesn't handle the underflow and overflow cases.
+// The parameter lostPrecision indicates whether the mantissa passed had already
+// lost precision during any preprocessing
 func roundHalfTowardsZero(signBit, exponentBits,
-	mantissaBits uint32) (Bits, big.Accuracy) {
+	mantissaBits uint32, lostPrecision bool) (Bits, big.Accuracy) {
 
 	mantissaF16Precision := mantissaBits & f32Float16MantissaMask
 	mantissaExtraPrecision := mantissaBits & f32Float16HalfSubnormalMask
@@ -30,13 +32,18 @@ func roundHalfTowardsZero(signBit, exponentBits,
 		addedOne = true
 	}
 
+	if mantissaExtraPrecision == f32Float16HalfSubnormalLSB && lostPrecision {
+		exponentMantissaComposite += 1
+		addedOne = true
+	}
+
 	// All we need to do now is attach the sign
 	resultVal := Bits(float16Sign | exponentMantissaComposite)
 	resultAcc := big.Exact
 
 	// Result is larger if the input was positive and we added 1, or
 	// if the input was negative and we truncated.
-	if mantissaExtraPrecision != 0 {
+	if mantissaExtraPrecision != 0 || lostPrecision {
 		resultAcc = big.Below
 		if (float16Sign == 0) == addedOne {
 			resultAcc = big.Above

--- a/pkg/float16bits/roundhalftowardszero.go
+++ b/pkg/float16bits/roundhalftowardszero.go
@@ -32,6 +32,9 @@ func roundHalfTowardsZero(signBit, exponentBits,
 		addedOne = true
 	}
 
+	// If extra precision was lost before, then we need to add one if we're
+	// halfway through in the adjusted mantissa (because this means we're
+	// actually greater than the midpoint)
 	if mantissaExtraPrecision == f32Float16HalfSubnormalLSB && lostPrecision {
 		exponentMantissaComposite += 1
 		addedOne = true

--- a/pkg/float16bits/roundhalfup.go
+++ b/pkg/float16bits/roundhalfup.go
@@ -30,6 +30,14 @@ func roundHalfTowardsPositiveInf(signBit, exponentBits,
 		addedOne = true
 	}
 
+	// If extra precision was lost before, then we need to add one if we're
+	// halfway through in the adjusted mantissa (because this means we're
+	// actually greater than the midpoint)
+	if mantissaExtraPrecision == f32Float16HalfSubnormalLSB && lostPrecision {
+		exponentMantissaComposite += 1
+		addedOne = true
+	}
+
 	// In the case that we're halfway through,
 	// We add 1, only if the sign was positive, otherwise we truncate
 	if (mantissaExtraPrecision ==

--- a/pkg/float16bits/roundhalfup.go
+++ b/pkg/float16bits/roundhalfup.go
@@ -12,7 +12,7 @@ import (
 // mantissaBits must be passed in their float32 locations.
 // NOTE: This doesn't handle the underflow and overflow cases.
 func roundHalfTowardsPositiveInf(signBit, exponentBits,
-	mantissaBits uint32) (Bits, big.Accuracy) {
+	mantissaBits uint32, lostPrecision bool) (Bits, big.Accuracy) {
 
 	mantissaF16Precision := mantissaBits & f32Float16MantissaMask
 	mantissaExtraPrecision := mantissaBits & f32Float16HalfSubnormalMask
@@ -33,7 +33,7 @@ func roundHalfTowardsPositiveInf(signBit, exponentBits,
 	// In the case that we're halfway through,
 	// We add 1, only if the sign was positive, otherwise we truncate
 	if (mantissaExtraPrecision ==
-		f32Float16HalfSubnormalLSB) && (float16Sign == 0) {
+		f32Float16HalfSubnormalLSB) && (float16Sign == 0) && !lostPrecision {
 		exponentMantissaComposite += 1
 		addedOne = true
 	}
@@ -45,7 +45,7 @@ func roundHalfTowardsPositiveInf(signBit, exponentBits,
 
 	// Result is larger if the input was positive and we added 1, or
 	// if the input was negative and we truncated.
-	if mantissaExtraPrecision != 0 {
+	if mantissaExtraPrecision != 0 || lostPrecision {
 		resultAcc = big.Below
 		if (float16Sign == 0) == addedOne {
 			resultAcc = big.Above

--- a/pkg/float16bits/roundnearesteven.go
+++ b/pkg/float16bits/roundnearesteven.go
@@ -12,8 +12,8 @@ import (
 // exponentBits must be passed with the float16 bias applied
 // mantissaBits must be passed in their float32 locations.
 // NOTE: This doesn't handle the underflow and overflow cases.
-func roundNearestEven(signBit, exponentBits, mantissaBits uint32) (Bits,
-	big.Accuracy) {
+func roundNearestEven(signBit, exponentBits, mantissaBits uint32,
+	lostPrecision bool) (Bits, big.Accuracy) {
 
 	// For rounding to nearest even, we round to the number that is closest and
 	// break ties by rounding towards the number that is even (LSB is 0)
@@ -46,7 +46,7 @@ func roundNearestEven(signBit, exponentBits, mantissaBits uint32) (Bits,
 	// In the case we're at the mid-point, we only add 1, if the LSB of the
 	// float32 retained mantissa is 1
 	if (mantissaF32LSB != 0) && (mantissaExtraPrecision ==
-		f32Float16HalfSubnormalLSB) {
+		f32Float16HalfSubnormalLSB) && !lostPrecision {
 		exponentMantissaComposite += 1
 		addedOne = true
 	}
@@ -58,7 +58,7 @@ func roundNearestEven(signBit, exponentBits, mantissaBits uint32) (Bits,
 
 	// Result is larger if the input was positive and we added 1, or
 	// if the input was negative and we truncated.
-	if mantissaExtraPrecision != 0 {
+	if mantissaExtraPrecision != 0 || lostPrecision {
 		resultAcc = big.Below
 		if (float16Sign == 0) == addedOne {
 			resultAcc = big.Above

--- a/pkg/float16bits/roundnearesteven.go
+++ b/pkg/float16bits/roundnearesteven.go
@@ -42,6 +42,14 @@ func roundNearestEven(signBit, exponentBits, mantissaBits uint32,
 		addedOne = true
 	}
 
+	// If extra precision was lost before, then we need to add one if we're
+	// halfway through in the adjusted mantissa (because this means we're
+	// actually greater than the midpoint)
+	if mantissaExtraPrecision == f32Float16HalfSubnormalLSB && lostPrecision {
+		exponentMantissaComposite += 1
+		addedOne = true
+	}
+
 	mantissaF32LSB := mantissaBits & f32Float16SubnormalLSB
 	// In the case we're at the mid-point, we only add 1, if the LSB of the
 	// float32 retained mantissa is 1

--- a/pkg/float16bits/roundnearestodd.go
+++ b/pkg/float16bits/roundnearestodd.go
@@ -12,7 +12,10 @@ import (
 // exponentBits must be passed with the float16 bias applied
 // mantissaBits must be passed in their float32 locations.
 // NOTE: This doesn't handle the underflow and overflow cases.
-func roundNearestOdd(signBit, exponentBits, mantissaBits uint32) (Bits,
+// The parameter lostPrecision indicates whether the mantissa passed had already
+// lost precision during any preprocessing
+func roundNearestOdd(signBit, exponentBits, mantissaBits uint32,
+	lostPrecision bool) (Bits,
 	big.Accuracy) {
 
 	// For rounding to nearest even, we round to the number that is closest and
@@ -46,7 +49,7 @@ func roundNearestOdd(signBit, exponentBits, mantissaBits uint32) (Bits,
 	// In the case we're at the mid-point, we only add 1, if the LSB of the
 	// float32 retained mantissa is 0
 	if (mantissaF32LSB == 0) && (mantissaExtraPrecision ==
-		f32Float16HalfSubnormalLSB) {
+		f32Float16HalfSubnormalLSB) && !lostPrecision {
 		exponentMantissaComposite += 1
 		addedOne = true
 	}
@@ -58,7 +61,7 @@ func roundNearestOdd(signBit, exponentBits, mantissaBits uint32) (Bits,
 
 	// Result is larger if the input was positive and we added 1, or
 	// if the input was negative and we truncated.
-	if mantissaExtraPrecision != 0 {
+	if mantissaExtraPrecision != 0 || lostPrecision {
 		resultAcc = big.Below
 		if (float16Sign == 0) == addedOne {
 			resultAcc = big.Above

--- a/pkg/float16bits/roundnearestodd.go
+++ b/pkg/float16bits/roundnearestodd.go
@@ -45,6 +45,14 @@ func roundNearestOdd(signBit, exponentBits, mantissaBits uint32,
 		addedOne = true
 	}
 
+	// If extra precision was lost before, then we need to add one if we're
+	// halfway through in the adjusted mantissa (because this means we're
+	// actually greater than the midpoint)
+	if mantissaExtraPrecision == f32Float16HalfSubnormalLSB && lostPrecision {
+		exponentMantissaComposite += 1
+		addedOne = true
+	}
+
 	mantissaF32LSB := mantissaBits & f32Float16SubnormalLSB
 	// In the case we're at the mid-point, we only add 1, if the LSB of the
 	// float32 retained mantissa is 0

--- a/pkg/float16bits/roundtowardszero.go
+++ b/pkg/float16bits/roundtowardszero.go
@@ -11,13 +11,14 @@ import (
 // exponentBits must be passed with the float16 bias applied
 // mantissaBits must be passed in their float32 locations.
 // NOTE: This doesn't handle the underflow and overflow cases.
-func roundTowardsZero(signBit, exponentBits, mantissaBits uint32) (Bits,
-	big.Accuracy) {
-	return truncate(signBit, exponentBits, mantissaBits)
+func roundTowardsZero(signBit, exponentBits, mantissaBits uint32,
+	lostPrecision bool) (Bits, big.Accuracy) {
+	return truncate(signBit, exponentBits, mantissaBits, lostPrecision)
 }
 
 // truncation is the same as rounding towards zero
-func truncate(signBit, exponentBits, mantissaBits uint32) (Bits, big.Accuracy) {
+func truncate(signBit, exponentBits, mantissaBits uint32,
+	lostPrecision bool) (Bits, big.Accuracy) {
 	mantissaF16Precision := mantissaBits & f32Float16MantissaMask
 	mantissaExtraPrecision := mantissaBits & f32Float16HalfSubnormalMask
 
@@ -31,7 +32,7 @@ func truncate(signBit, exponentBits, mantissaBits uint32) (Bits, big.Accuracy) {
 
 	// If there was extra precision, then the number did not fit in the
 	// float32 format, so we need to report the status appropriately
-	if mantissaExtraPrecision != 0 {
+	if mantissaExtraPrecision != 0 || lostPrecision {
 		if signBit == 0 {
 			resultAcc = big.Below
 		} else {

--- a/pkg/float32bits/float32.go
+++ b/pkg/float32bits/float32.go
@@ -208,6 +208,10 @@ func FromFloat64(input float64, rm floatBit.RoundingMode,
 	alignedMantissa := mantissaBits
 	adjustedExponent := uint64(actualExponent + ExponentBias)
 
+	// Value that indicates whether any precision was lost when preprocessing
+	// the mantissa before passing it down to the rounding routines
+	lostPrecision := false
+
 	// Before performing any rounding, we need to make sure this exponent
 	// can actually be represented in the float32 format. If the exponent,
 	// is smaller than the minimum exponent allowed in float32 (-126), this
@@ -236,7 +240,6 @@ func FromFloat64(input float64, rm floatBit.RoundingMode,
 
 		// For accurately determining underflow, we also need to check
 		// if we shifted any 1s to the right
-		lostPrecision := false
 
 		// Now, to align the bits of the original format, with the mantissa
 		// of the destination format as a subnormal, we have to shift right
@@ -285,28 +288,28 @@ func FromFloat64(input float64, rm floatBit.RoundingMode,
 	switch rm {
 	case floatBit.RoundTowardsZero:
 		resultVal, resultAcc = roundTowardsZero(signBit,
-			adjustedExponent, alignedMantissa)
+			adjustedExponent, alignedMantissa, lostPrecision)
 	case floatBit.RoundTowardsNegativeInf:
 		resultVal, resultAcc = roundTowardsNegativeInf(signBit,
-			adjustedExponent, alignedMantissa)
+			adjustedExponent, alignedMantissa, lostPrecision)
 	case floatBit.RoundTowardsPositiveInf:
 		resultVal, resultAcc = roundTowardsPositiveInf(signBit,
-			adjustedExponent, alignedMantissa)
+			adjustedExponent, alignedMantissa, lostPrecision)
 	case floatBit.RoundHalfTowardsZero:
 		resultVal, resultAcc = roundHalfTowardsZero(signBit, adjustedExponent,
-			alignedMantissa)
+			alignedMantissa, lostPrecision)
 	case floatBit.RoundHalfTowardsNegativeInf:
 		resultVal, resultAcc = roundHalfTowardsNegativeInf(signBit,
-			adjustedExponent, alignedMantissa)
+			adjustedExponent, alignedMantissa, lostPrecision)
 	case floatBit.RoundHalfTowardsPositiveInf:
 		resultVal, resultAcc = roundHalfTowardsPositiveInf(signBit,
-			adjustedExponent, alignedMantissa)
+			adjustedExponent, alignedMantissa, lostPrecision)
 	case floatBit.RoundNearestEven:
 		resultVal, resultAcc = roundNearestEven(signBit, adjustedExponent,
-			alignedMantissa)
+			alignedMantissa, lostPrecision)
 	case floatBit.RoundNearestOdd:
 		resultVal, resultAcc = roundNearestOdd(signBit, adjustedExponent,
-			alignedMantissa)
+			alignedMantissa, lostPrecision)
 	}
 
 	return resultVal, resultAcc, floatBit.Fits

--- a/pkg/float32bits/float32_test.go
+++ b/pkg/float32bits/float32_test.go
@@ -214,7 +214,7 @@ func TestRoundTowardsZero(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run("RoundTowardsZero", func(t *testing.T) {
-			resultVal, resultAcc := truncate(tt.signBit, tt.exponentBits, tt.mantissaBits)
+			resultVal, resultAcc := truncate(tt.signBit, tt.exponentBits, tt.mantissaBits, false)
 			if (resultVal != tt.goldenVal) || (resultAcc != tt.goldenAcc) {
 				t.Logf("Failed Input Set:\n")
 				t.Logf("signBit: %#016x, exponentBits: %#016x, mantissaBits: %#016x", tt.signBit, tt.exponentBits, tt.mantissaBits)
@@ -283,7 +283,7 @@ func TestRoundTowardsPositiveInf(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run("RoundTowardsPositiveInf", func(t *testing.T) {
-			resultVal, resultAcc := roundTowardsPositiveInf(tt.signBit, tt.exponentBits, tt.mantissaBits)
+			resultVal, resultAcc := roundTowardsPositiveInf(tt.signBit, tt.exponentBits, tt.mantissaBits, false)
 			if (resultVal != tt.goldenVal) || (resultAcc != tt.goldenAcc) {
 				t.Logf("Failed Input Set:\n")
 				t.Logf("signBit: %#016x, exponentBits: %#016x, mantissaBits: %#016x", tt.signBit, tt.exponentBits, tt.mantissaBits)
@@ -351,7 +351,7 @@ func TestRoundTowardsNegativeInf(t *testing.T) {
 	}
 	for _, tt := range testCases {
 		t.Run("RoundTowardsNegativeInf", func(t *testing.T) {
-			resultVal, resultAcc := roundTowardsNegativeInf(tt.signBit, tt.exponentBits, tt.mantissaBits)
+			resultVal, resultAcc := roundTowardsNegativeInf(tt.signBit, tt.exponentBits, tt.mantissaBits, false)
 			if (resultVal != tt.goldenVal) || (resultAcc != tt.goldenAcc) {
 				t.Logf("Failed Input Set:\n")
 				t.Logf("signBit: %#016x, exponentBits: %#016x, mantissaBits: %#016x", tt.signBit, tt.exponentBits, tt.mantissaBits)
@@ -494,7 +494,7 @@ func TestRoundHalfTowardsZero(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run("RoundHalfTowardsZero", func(t *testing.T) {
-			resultVal, resultAcc := roundHalfTowardsZero(tt.signBit, tt.exponentBits, tt.mantissaBits)
+			resultVal, resultAcc := roundHalfTowardsZero(tt.signBit, tt.exponentBits, tt.mantissaBits, false)
 			if (resultVal != tt.goldenVal) || (resultAcc != tt.goldenAcc) {
 				t.Logf("Failed Input Set:\n")
 				t.Logf("signBit: %#016x, exponentBits: %#016x, mantissaBits: %#016x", tt.signBit, tt.exponentBits, tt.mantissaBits)
@@ -637,7 +637,7 @@ func TestRoundHalfTowardsPositiveInf(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run("RoundHalfTowardsPositiveInf", func(t *testing.T) {
-			resultVal, resultAcc := roundHalfTowardsPositiveInf(tt.signBit, tt.exponentBits, tt.mantissaBits)
+			resultVal, resultAcc := roundHalfTowardsPositiveInf(tt.signBit, tt.exponentBits, tt.mantissaBits, false)
 			if (resultVal != tt.goldenVal) || (resultAcc != tt.goldenAcc) {
 				t.Logf("Failed Input Set:\n")
 				t.Logf("signBit: %#016x, exponentBits: %#016x, mantissaBits: %#016x", tt.signBit, tt.exponentBits, tt.mantissaBits)
@@ -780,7 +780,7 @@ func TestRoundHalfTowardsNegativeInf(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run("RoundHalfTowardsNegativeInf", func(t *testing.T) {
-			resultVal, resultAcc := roundHalfTowardsNegativeInf(tt.signBit, tt.exponentBits, tt.mantissaBits)
+			resultVal, resultAcc := roundHalfTowardsNegativeInf(tt.signBit, tt.exponentBits, tt.mantissaBits, false)
 			if (resultVal != tt.goldenVal) || (resultAcc != tt.goldenAcc) {
 				t.Logf("Failed Input Set:\n")
 				t.Logf("signBit: %#016x, exponentBits: %#016x, mantissaBits: %#016x", tt.signBit, tt.exponentBits, tt.mantissaBits)
@@ -961,7 +961,7 @@ func TestRoundNearestEven(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run("RoundHalfTowardsNegativeInf", func(t *testing.T) {
-			resultVal, resultAcc := roundNearestEven(tt.signBit, tt.exponentBits, tt.mantissaBits)
+			resultVal, resultAcc := roundNearestEven(tt.signBit, tt.exponentBits, tt.mantissaBits, false)
 			if (resultVal != tt.goldenVal) || (resultAcc != tt.goldenAcc) {
 				t.Logf("Failed Input Set:\n")
 				t.Logf("signBit: %#016x, exponentBits: %#016x, mantissaBits: %#016x", tt.signBit, tt.exponentBits, tt.mantissaBits)
@@ -1134,7 +1134,7 @@ func TestRoundNearestOdd(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run("RoundHalfTowardsNegativeInf", func(t *testing.T) {
-			resultVal, resultAcc := roundNearestOdd(tt.signBit, tt.exponentBits, tt.mantissaBits)
+			resultVal, resultAcc := roundNearestOdd(tt.signBit, tt.exponentBits, tt.mantissaBits, false)
 			if (resultVal != tt.goldenVal) || (resultAcc != tt.goldenAcc) {
 				t.Logf("Failed Input Set:\n")
 				t.Logf("signBit: %#016x, exponentBits: %#016x, mantissaBits: %#016x", tt.signBit, tt.exponentBits, tt.mantissaBits)

--- a/pkg/float32bits/roundhalfdown.go
+++ b/pkg/float32bits/roundhalfdown.go
@@ -30,6 +30,14 @@ func roundHalfTowardsNegativeInf(signBit, exponentBits,
 		addedOne = true
 	}
 
+	// If extra precision was lost before, then we need to add one if we're
+	// halfway through in the adjusted mantissa (because this means we're
+	// actually greater than the midpoint)
+	if mantissaExtraPrecision == f64float32HalfSubnormalLSB && lostPrecision {
+		exponentMantissaComposite += 1
+		addedOne = true
+	}
+
 	// In the case that we're halfway through,
 	// We add 1, only if the sign was negative, otherwise we truncate
 	if (mantissaExtraPrecision ==

--- a/pkg/float32bits/roundhalftowardszero.go
+++ b/pkg/float32bits/roundhalftowardszero.go
@@ -32,6 +32,9 @@ func roundHalfTowardsZero(signBit, exponentBits,
 		addedOne = true
 	}
 
+	// If extra precision was lost before, then we need to add one if we're
+	// halfway through in the adjusted mantissa (because this means we're
+	// actually greater than the midpoint)
 	if mantissaExtraPrecision == f64float32HalfSubnormalLSB && lostPrecision {
 		exponentMantissaComposite += 1
 		addedOne = true

--- a/pkg/float32bits/roundhalftowardszero.go
+++ b/pkg/float32bits/roundhalftowardszero.go
@@ -9,8 +9,10 @@ import "math/big"
 // exponentBits must be passed with the float32 bias applied
 // mantissaBits must be passed in their float64 locations.
 // NOTE: This doesn't handle the underflow and overflow cases.
+// The parameter lostPrecision indicates whether the mantissa passed had already
+// lost precision during any preprocessing
 func roundHalfTowardsZero(signBit, exponentBits,
-	mantissaBits uint64) (Bits, big.Accuracy) {
+	mantissaBits uint64, lostPrecision bool) (Bits, big.Accuracy) {
 
 	mantissaF32Precision := mantissaBits & f64float32MantissaMask
 	mantissaExtraPrecision := mantissaBits & f64float32HalfSubnormalMask
@@ -30,13 +32,18 @@ func roundHalfTowardsZero(signBit, exponentBits,
 		addedOne = true
 	}
 
+	if mantissaExtraPrecision == f64float32HalfSubnormalLSB && lostPrecision {
+		exponentMantissaComposite += 1
+		addedOne = true
+	}
+
 	// All we need to do now is attach the sign
 	resultVal := Bits(float32Sign | exponentMantissaComposite)
 	resultAcc := big.Exact
 
 	// Result is larger if the input was positive and we added 1, or
 	// if the input was negative and we truncated.
-	if mantissaExtraPrecision != 0 {
+	if mantissaExtraPrecision != 0 || lostPrecision {
 		resultAcc = big.Below
 		if (float32Sign == 0) == addedOne {
 			resultAcc = big.Above

--- a/pkg/float32bits/roundhalfup.go
+++ b/pkg/float32bits/roundhalfup.go
@@ -32,6 +32,14 @@ func roundHalfTowardsPositiveInf(signBit, exponentBits,
 		addedOne = true
 	}
 
+	// If extra precision was lost before, then we need to add one if we're
+	// halfway through in the adjusted mantissa (because this means we're
+	// actually greater than the midpoint)
+	if mantissaExtraPrecision == f64float32HalfSubnormalLSB && lostPrecision {
+		exponentMantissaComposite += 1
+		addedOne = true
+	}
+
 	// In the case that we're halfway through,
 	// We add 1, only if the sign was positive, otherwise we truncate
 	if (mantissaExtraPrecision ==

--- a/pkg/float32bits/roundhalfup.go
+++ b/pkg/float32bits/roundhalfup.go
@@ -11,8 +11,10 @@ import (
 // exponentBits must be passed with the float32 bias applied
 // mantissaBits must be passed in their float64 locations.
 // NOTE: This doesn't handle the underflow and overflow cases.
+// The parameter lostPrecision indicates whether the mantissa passed had already
+// lost precision during any preprocessing
 func roundHalfTowardsPositiveInf(signBit, exponentBits,
-	mantissaBits uint64) (Bits, big.Accuracy) {
+	mantissaBits uint64, lostPrecision bool) (Bits, big.Accuracy) {
 
 	mantissaF32Precision := mantissaBits & f64float32MantissaMask
 	mantissaExtraPrecision := mantissaBits & f64float32HalfSubnormalMask
@@ -33,7 +35,7 @@ func roundHalfTowardsPositiveInf(signBit, exponentBits,
 	// In the case that we're halfway through,
 	// We add 1, only if the sign was positive, otherwise we truncate
 	if (mantissaExtraPrecision ==
-		f64float32HalfSubnormalLSB) && (float32Sign == 0) {
+		f64float32HalfSubnormalLSB) && (float32Sign == 0) && !lostPrecision {
 		exponentMantissaComposite += 1
 		addedOne = true
 	}
@@ -45,7 +47,7 @@ func roundHalfTowardsPositiveInf(signBit, exponentBits,
 
 	// Result is larger if the input was positive and we added 1, or
 	// if the input was negative and we truncated.
-	if mantissaExtraPrecision != 0 {
+	if mantissaExtraPrecision != 0 || lostPrecision {
 		resultAcc = big.Below
 		if (float32Sign == 0) == addedOne {
 			resultAcc = big.Above

--- a/pkg/float32bits/roundnearesteven.go
+++ b/pkg/float32bits/roundnearesteven.go
@@ -12,8 +12,10 @@ import (
 // exponentBits must be passed with the float32 bias applied
 // mantissaBits must be passed in their float64 locations.
 // NOTE: This doesn't handle the underflow and overflow cases.
-func roundNearestEven(signBit, exponentBits, mantissaBits uint64) (Bits,
-	big.Accuracy) {
+// The parameter lostPrecision indicates whether the mantissa passed had already
+// lost precision during any preprocessing
+func roundNearestEven(signBit, exponentBits, mantissaBits uint64,
+	lostPrecision bool) (Bits, big.Accuracy) {
 
 	// For rounding to nearest even, we round to the number that is closest and
 	// break ties by rounding towards the number that is even (LSB is 0)
@@ -46,7 +48,7 @@ func roundNearestEven(signBit, exponentBits, mantissaBits uint64) (Bits,
 	// In the case we're at the mid-point, we only add 1, if the LSB of the
 	// float32 retained mantissa is 1
 	if (mantissaF32LSB != 0) && (mantissaExtraPrecision ==
-		f64float32HalfSubnormalLSB) {
+		f64float32HalfSubnormalLSB) && !lostPrecision {
 		exponentMantissaComposite += 1
 		addedOne = true
 	}
@@ -58,7 +60,7 @@ func roundNearestEven(signBit, exponentBits, mantissaBits uint64) (Bits,
 
 	// Result is larger if the input was positive and we added 1, or
 	// if the input was negative and we truncated.
-	if mantissaExtraPrecision != 0 {
+	if mantissaExtraPrecision != 0 || lostPrecision {
 		resultAcc = big.Below
 		if (float32Sign == 0) == addedOne {
 			resultAcc = big.Above

--- a/pkg/float32bits/roundnearesteven.go
+++ b/pkg/float32bits/roundnearesteven.go
@@ -44,6 +44,14 @@ func roundNearestEven(signBit, exponentBits, mantissaBits uint64,
 		addedOne = true
 	}
 
+	// If extra precision was lost before, then we need to add one if we're
+	// halfway through in the adjusted mantissa (because this means we're
+	// actually greater than the midpoint)
+	if mantissaExtraPrecision == f64float32HalfSubnormalLSB && lostPrecision {
+		exponentMantissaComposite += 1
+		addedOne = true
+	}
+
 	mantissaF32LSB := mantissaBits & f64float32SubnormalLSB
 	// In the case we're at the mid-point, we only add 1, if the LSB of the
 	// float32 retained mantissa is 1

--- a/pkg/float32bits/roundnearestodd.go
+++ b/pkg/float32bits/roundnearestodd.go
@@ -44,6 +44,14 @@ func roundNearestOdd(signBit, exponentBits, mantissaBits uint64,
 		addedOne = true
 	}
 
+	// If extra precision was lost before, then we need to add one if we're
+	// halfway through in the adjusted mantissa (because this means we're
+	// actually greater than the midpoint)
+	if mantissaExtraPrecision == f64float32HalfSubnormalLSB && lostPrecision {
+		exponentMantissaComposite += 1
+		addedOne = true
+	}
+
 	mantissaF32LSB := mantissaBits & f64float32SubnormalLSB
 	// In the case we're at the mid-point, we only add 1, if the LSB of the
 	// float32 retained mantissa is 0

--- a/pkg/float32bits/roundtowardszero.go
+++ b/pkg/float32bits/roundtowardszero.go
@@ -11,13 +11,14 @@ import (
 // exponentBits must be passed with the float32 bias applied
 // mantissaBits must be passed in their float64 locations.
 // NOTE: This doesn't handle the underflow and overflow cases.
-func roundTowardsZero(signBit, exponentBits, mantissaBits uint64) (Bits,
-	big.Accuracy) {
-	return truncate(signBit, exponentBits, mantissaBits)
+func roundTowardsZero(signBit, exponentBits, mantissaBits uint64,
+	lostPrecision bool) (Bits, big.Accuracy) {
+	return truncate(signBit, exponentBits, mantissaBits, lostPrecision)
 }
 
 // truncation is the same as rounding towards zero
-func truncate(signBit, exponentBits, mantissaBits uint64) (Bits, big.Accuracy) {
+func truncate(signBit, exponentBits, mantissaBits uint64,
+	lostPrecision bool) (Bits, big.Accuracy) {
 	mantissaF32Precision := mantissaBits & f64float32MantissaMask
 	mantissaExtraPrecision := mantissaBits & f64float32HalfSubnormalMask
 
@@ -31,7 +32,7 @@ func truncate(signBit, exponentBits, mantissaBits uint64) (Bits, big.Accuracy) {
 
 	// If there was extra precision, then the number did not fit in the
 	// float32 format, so we need to report the status appropriately
-	if mantissaExtraPrecision != 0 {
+	if mantissaExtraPrecision != 0 || lostPrecision {
 		if signBit == 0 {
 			resultAcc = big.Below
 		} else {

--- a/pkg/float32bits/roundup.go
+++ b/pkg/float32bits/roundup.go
@@ -13,11 +13,12 @@ import (
 // mantissaBits must be passed in their float64 locations.
 // NOTE: This doesn't handle the underflow and overflow cases.
 func roundTowardsPositiveInf(signBit, exponentBits,
-	mantissaBits uint64) (Bits, big.Accuracy) {
-	return roundUp(signBit, exponentBits, mantissaBits)
+	mantissaBits uint64, lostPrecision bool) (Bits, big.Accuracy) {
+	return roundUp(signBit, exponentBits, mantissaBits, lostPrecision)
 }
 
-func roundUp(signBit, exponentBits, mantissaBits uint64) (Bits, big.Accuracy) {
+func roundUp(signBit, exponentBits, mantissaBits uint64,
+	lostPrecision bool) (Bits, big.Accuracy) {
 
 	mantissaF32Precision := mantissaBits & f64float32MantissaMask
 	mantissaExtraPrecision := mantissaBits & f64float32HalfSubnormalMask
@@ -33,7 +34,7 @@ func roundUp(signBit, exponentBits, mantissaBits uint64) (Bits, big.Accuracy) {
 	exponentMantissaComposite := (float32Exponent | float32Mantissa)
 
 	// If positive and there is extra precision, then add 1
-	if (float32Sign == 0) && (mantissaExtraPrecision != 0) {
+	if (float32Sign == 0) && (mantissaExtraPrecision != 0 || lostPrecision) {
 		exponentMantissaComposite += 1
 	}
 	// Since, we don't handle overflow, all we need to do now is attach the sign
@@ -41,7 +42,7 @@ func roundUp(signBit, exponentBits, mantissaBits uint64) (Bits, big.Accuracy) {
 
 	resultAcc := big.Exact
 	// If there was extra precision bits set, then we need to
-	if mantissaExtraPrecision != 0 {
+	if mantissaExtraPrecision != 0 || lostPrecision {
 		// We always round to a larger value
 		resultAcc = big.Above
 	}


### PR DESCRIPTION
Bug Fix to https://github.com/shantanu-gontia/float-conv/issues/4

Also, the rounding modes were also affected by this. This PR fixes those issues as well

Also, the `roundhalfdown.go` was named incorrectly as `roundhalfdown,.go`. Fixed that.